### PR TITLE
feat: add hold down time and publish while pressing the button

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ It aim to prevent malfunction of button manipulation.
   - from [dio_ros_driver](https://github.com/tier4/dio_ros_driver)
     - `/dio/din[0-7]` \[[dio_ros_driver/msg/DIOPort](https://github.com/tier4/dio_ros_driver/blob/develop/ros2/msg/DIOPort.msg)\]:<br>GPIO input topic. It is output at regular intervals regardless of whether the button is ON or OFF.<br>Which of `din[0-7]` is chosen depends on the `port_name` of the [Launch arguments](#launch-arguments).
 - output
-  - to [engage_srv_converter](https://github.com/eve-autonomy/engage_srv_converter) and [autoware_state_machine](https://github.com/eve-autonomy/autoware_state_machine)
-    - `(button_name)_manager/output/(button_name)` \[[autoware_state_machine_msgs/msg/VehicleButton](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/VehicleButton.msg)\]:<br>Output indicating that the button is pressed.<br>See [Launch arguments](#launch-arguments) for `button_name`.
+  - to [engage_srv_converter](https://github.com/eve-autonomy/engage_srv_converter) and [button_output_selector](https://github.com/eve-autonomy/button_output_selector)
+    - `(button_name)_manager/output/(button_name)` \[[autoware_state_machine_msgs/msg/VehicleButton](https://github.com/eve-autonomy/autoware_state_machine_msgs/blob/main/msg/VehicleButton.msg)\]:<br>Output indicating the time the button is pressed and whether the button is released after being pressed.<br>See [Launch arguments](#launch-arguments) for `button_name`.
 
 ## Node Graph
 In this figure, `/engage_button_manager` and `/delivery_reservation_button_manager` are both execution node names of this node.
@@ -32,6 +32,7 @@ The name is changed with  a launch argument `button_name`.
 |Name|Description|
 |:---|:----------|
 |active_polarity|This inverts mutually high (ON) and low (OFF) values of a DI signal.<br>- True: With inversion. - False: No inversion.|
+|is_publish_while_pressing_button|This defines whether or not the button should announce that it is being pressed while the button is being pressed.|
 
 ### GPIO noise reduction parameters
 |ID|Name|Description|

--- a/docs/node_graph.pu
+++ b/docs/node_graph.pu
@@ -4,11 +4,11 @@ usecase "/dio_ros_driver"
 usecase "/engage_button_manager" #LightCoral
 usecase "/delivery_reservation_button_manager" #LightCoral
 usecase "/engage_srv_converter"
-usecase "/autoware_state_machine"
+usecase "/button_output_selector"
 
 (/dio_ros_driver) --> (/engage_button_manager) : /dio/din0
 (/engage_button_manager) --> (/engage_srv_converter) : /engage_button_manager/output/engage_button
 (/dio_ros_driver) --> (/delivery_reservation_button_manager) : /dio/din1
-(/delivery_reservation_button_manager) --> (/autoware_state_machine) : /delivery_reservation_button_manager/output/delivery_reservation_button
+(/delivery_reservation_button_manager) --> (/button_output_selector) : /delivery_reservation_button_manager/output/delivery_reservation_button
 
 @enduml

--- a/include/button_manager/button_manager.hpp
+++ b/include/button_manager/button_manager.hpp
@@ -57,6 +57,7 @@ private:
   float not_pressed_period_threshold_after_pressed_ = 0.5;
   float max_allowable_period_of_pressing_ = 30.0;
   bool active_polarity_ = true;
+  bool is_publish_while_pressing_button_ = false;
   float hold_down_time_ = 0.0;
 
   // Initial "port_value_" sets to false as OFF. This is going to overwritten by a first DIO input.

--- a/include/button_manager/button_manager.hpp
+++ b/include/button_manager/button_manager.hpp
@@ -57,6 +57,7 @@ private:
   float not_pressed_period_threshold_after_pressed_ = 0.5;
   float max_allowable_period_of_pressing_ = 30.0;
   bool active_polarity_ = true;
+  float hold_down_time_ = 0.0;
 
   // Initial "port_value_" sets to false as OFF. This is going to overwritten by a first DIO input.
   bool port_value_ = false;
@@ -65,6 +66,7 @@ private:
   void Callback(const dio_ros_driver::msg::DIOPort::ConstSharedPtr msg);
   void ButtonState(const bool button_status_change);
   bool checkStateChangeWithRemovingChattering(const bool is_button_on);
+  void PulishButtonPressNotification(const bool is_button_released, const float hold_down_time);
 };
 
 }  // namespace button_manager

--- a/launch/button_manager.launch.xml
+++ b/launch/button_manager.launch.xml
@@ -17,9 +17,11 @@
 <launch>
     <arg name="button_name" default="button" />
     <arg name="port_name" default="din0" />
+    <arg name="is_publish_while_pressing_button" default="false" />
 
     <node pkg="button_manager" exec="button_manager_node" name="$(var button_name)_manager" output="screen">
       <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)" />
+      <param name="is_publish_while_pressing_button" value="$(var is_publish_while_pressing_button)" />
       <remap from="button_out" to="~/output/$(var button_name)" />
       <remap from="button_in" to="/dio/$(var port_name)" />
       <param from="$(find-pkg-share button_manager)/config/button_manager.param.yaml" />

--- a/src/button_manager.cpp
+++ b/src/button_manager.cpp
@@ -43,6 +43,8 @@ ButtonManager::ButtonManager(const rclcpp::NodeOptions & options = rclcpp::NodeO
   max_allowable_period_of_pressing_ = this->declare_parameter<double>(
     "max_allowable_period_of_pressing", 1.0);
   active_polarity_ = this->declare_parameter<bool>("active_polarity", false);
+  is_publish_while_pressing_button_ = this->declare_parameter<bool>(
+    "is_publish_while_pressing_button", false);
 
   base_time_ = this->now();
 }
@@ -136,6 +138,9 @@ void ButtonManager::ButtonState(const bool button_status_change)
       }
 
       hold_down_time_ = elapsed_time;
+      if (is_publish_while_pressing_button_) {
+        PulishButtonPressNotification(false, elapsed_time);
+      }
       break;
     case BUTTON_OFF_AFTER_ON_WAIT:
       if (button_status_change == true) {


### PR DESCRIPTION
## Description

* Modified to publish the time the button is pressed as a topic.
* Add variable `is_publish_while_pressing_button` as rosparam.
* Change to publish the topic even while the button is pressed when `is_publish_while_pressing_button` is True.
* Modify README to match implementation.

## Related Links

eve-autonomy/shutdown_manager#1
eve-autonomy/button_output_selector#1
eve-autonomy/delivery_reservation_lamp_manager#6
eve-autonomy/autoware_state_machine#2
eve-autonomy/autoware_state_machine_msgs#1
eve-autonomy/proj_launch#6

## Review Procedure

 * [ ] Make sure the description is valid.
 * [ ] Make sure that what is described in the description matches the implementation.